### PR TITLE
Rename `vulnerable?` to `is_this_app_vulnerable?`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ config = {
 
 canary = Appcanary::Client.new(config)
 
-if canary.vulnerable?
+if canary.is_this_app_vulnerable?
   puts "you appear to have your ass in the air"
 end
 ```
@@ -91,7 +91,7 @@ Appcanary.gemfile_lock_path = "/path/to/gemfile"
 The gem may then be used without instantiating a client, like this:
 
 ```ruby
-if Appcanary.vulnerable? :critical
+if Appcanary.is_this_app_vulnerable? :critical
   puts "I see your shiny attack surface! It BIG!"
 end
 ```
@@ -132,7 +132,7 @@ configurations include the following items however.
 | Key                 | Required? | Description | Notes |
 | ------------------- | --------- | ----------- | ----- |
 | `api_key`           | Y         | Your Appcanary API key, found in your [Appcanary settings](https://appcanary.com/settings). | |
-| `gemfile_lock_path` | N*        | Path to your `Gemfile.lock`, which gets shipped to Appcanary for analysis. | Most of the time you can leave this undefined. *Be warned that the appcanary gem will error if Bundler is not loaded unless this is set. |
+| `gemfile_lock_path` | N         | Path to your `Gemfile.lock`, which gets shipped to Appcanary for analysis. | Most of the time you can leave this undefined. |
 | `monitor_name`      | Y*        | The base name for the monitor to be updated. *This is required if and only if you plan to use the `update_monitor` functionality. | If you're running in CI, the gem will attempt to acquire the name of the current branch and append that to your monitor name before sending the update. If a monitor does not already exist, it will be created. If this attribute is unset and the gem is loaded in the context of a Rails application, it will use the rails application name as the monitor name. |
 | `base_uri`          | N         | The url for the Appcanary service endpoint. | You should leave this unset unless you have a very good reason not to. |
 

--- a/bin/appcanary
+++ b/bin/appcanary
@@ -97,6 +97,8 @@ def run_appcanary_command
   when "check"
     run_check
   end
+rescue => e
+  puts e
 end
 
 run_appcanary_command

--- a/lib/appcanary/assert.rb
+++ b/lib/appcanary/assert.rb
@@ -10,7 +10,7 @@ module Appcanary
       @config = config
     end
 
-    def vulnerable?(criticality = nil)
+    def is_this_app_vulnerable?(criticality = nil)
       check do |response|
         vulnerable = response["meta"]["vulnerable"]
         if vulnerable == true || vulnerable == "true"

--- a/lib/appcanary/configuration.rb
+++ b/lib/appcanary/configuration.rb
@@ -139,9 +139,17 @@ Consult the following docs for more information:
     def base_uri=(val);          configuration.base_uri = val;          end
 
     # static API
-    def vulnerable?(criticality = nil); canary.vulnerable?(criticality); end
-    def update_monitor!;                canary.update_monitor!;          end
-    def check;                          canary.check;                    end
+    def is_this_app_vulnerable?(criticality = nil)
+      canary.is_this_app_vulnerable?(criticality)
+    end
+
+    def update_monitor!
+      canary.update_monitor!
+    end
+
+    def check
+      canary.check
+    end
 
     private
     def canary

--- a/lib/appcanary/configuration.rb
+++ b/lib/appcanary/configuration.rb
@@ -68,24 +68,19 @@ module Appcanary
       #      except working on this gem), default to prod appcanary.com.
       unless self.sufficient_for_check?
         yaml_file = "#{Dir.pwd}/#{APPCANARY_YAML}"
-        if File.exist?(yaml_file)
-          begin
-            load_yaml_config!(yaml_file)
-          rescue
-            load_yaml_config!("#{Bundler.root}/#{APPCANARY_YAML}") if defined?(Bundler)
-          end
-        else
-          raise ConfigurationError.new(
-                  "We couldn't find any Gemfile.locks to report on! Don't forget to configure it.")
+        begin
+          load_yaml_config!(yaml_file)
+        rescue
+          load_yaml_config!("#{Bundler.root}/#{APPCANARY_YAML}") if defined?(Bundler)
         end
       end
 
       # UX for validation
       errors = []
-      errors << "Appcanary.api_key = ???" if api_key.nil?
-      errors << "Appcanary.gemfile_lock_path = ???" if gemfile_lock_path.nil?
+      errors << "\tAppcanary.api_key = ???" if api_key.nil?
+      errors << "\tAppcanary.gemfile_lock_path = ???" if gemfile_lock_path.nil?
       unless errors.empty?
-        raise ConfigurationError.new("Missing configuration:\n\n#{errors.join("\n")}")
+        raise ConfigurationError.new("Missing configuration:\n#{errors.join("\n")}")
       end
 
       self
@@ -99,8 +94,9 @@ module Appcanary
         self.monitor_name      = yaml_config["monitor_name"]
         self.base_uri          = yaml_config["base_uri"] || APPCANARY_DEFAULT_BASE_URI
       rescue Errno::ENOENT
-        raise ConfigurationError.new("No valid configuration found")
+        # ignore, fall through
       rescue => e
+        # there was a file, but something was wrong with it
         raise ConfigurationError.new(e)
       end
     end
@@ -108,14 +104,13 @@ module Appcanary
 
   class ConfigurationError < RuntimeError
     SUFFIX = <<-EOS
-
 Consult the following docs for more information:
 - https://github.com/appcanary/appcanary.rb
 - https://appcanary.com/settings
     EOS
 
     def initialize(msg)
-      super(msg + SUFFIX)
+      super("#{msg}\n\n#{SUFFIX}")
     end
   end
 

--- a/lib/appcanary/tasks/appcanary/check.rake
+++ b/lib/appcanary/tasks/appcanary/check.rake
@@ -10,6 +10,8 @@ def run_check
       puts ref
     end
   end
+rescue => e
+  puts e
 end
 
 namespace :appcanary do

--- a/lib/appcanary/tasks/appcanary/monitor.rake
+++ b/lib/appcanary/tasks/appcanary/monitor.rake
@@ -1,15 +1,21 @@
 require "appcanary"
 require "rake"
 
+def run_update_monitor
+  Appcanary.update_monitor!
+rescue => e
+  puts e
+end
+
 namespace :appcanary do
   desc "Update the appcanary monitor for this project"
   if defined?(Rails)
     task :update_monitor => :environment do
-      Appcanary.update_monitor!
+      run_update_monitor
     end
   else
     task :update_monitor do
-      Appcanary.update_monitor!
+      run_update_monitor
     end
   end
 end

--- a/test/appcanary_test.rb
+++ b/test/appcanary_test.rb
@@ -121,15 +121,15 @@ describe Appcanary do
       end
 
       it "is not itself vulnerable" do
-        assert(!Appcanary.vulnerable?)
+        assert(!Appcanary.is_this_app_vulnerable?)
       end
 
       it "doesn't blow up for good criticalities" do
-        assert(!Appcanary.vulnerable?(:critical))
-        assert(!Appcanary.vulnerable?(:high))
-        assert(!Appcanary.vulnerable?(:medium))
-        assert(!Appcanary.vulnerable?(:low))
-        assert(!Appcanary.vulnerable?(:unknown))
+        assert(!Appcanary.is_this_app_vulnerable?(:critical))
+        assert(!Appcanary.is_this_app_vulnerable?(:high))
+        assert(!Appcanary.is_this_app_vulnerable?(:medium))
+        assert(!Appcanary.is_this_app_vulnerable?(:low))
+        assert(!Appcanary.is_this_app_vulnerable?(:unknown))
       end
 
       describe "#check" do
@@ -160,15 +160,15 @@ describe Appcanary do
       end
 
       it "is not itself vulnerable" do
-        assert(!@canary.vulnerable?)
+        assert(!@canary.is_this_app_vulnerable?)
       end
 
       it "doesn't blow up for good criticalities" do
-        assert(!@canary.vulnerable?(:critical))
-        assert(!@canary.vulnerable?(:high))
-        assert(!@canary.vulnerable?(:medium))
-        assert(!@canary.vulnerable?(:low))
-        assert(!@canary.vulnerable?(:unknown))
+        assert(!@canary.is_this_app_vulnerable?(:critical))
+        assert(!@canary.is_this_app_vulnerable?(:high))
+        assert(!@canary.is_this_app_vulnerable?(:medium))
+        assert(!@canary.is_this_app_vulnerable?(:low))
+        assert(!@canary.is_this_app_vulnerable?(:unknown))
       end
 
       describe "#check" do


### PR DESCRIPTION
We'll reuse `vulnerable?` later for a more generic interface.

This PR also removes some error handling that no longer makes sense, and cleans up how errors are reported by the command line tools.